### PR TITLE
fix: corrigir links quebrados no README da pasta BASICO

### DIFF
--- a/0-BASICO/README.md
+++ b/0-BASICO/README.md
@@ -2,7 +2,7 @@
 
 ## Conteúdos Relacionados
 
-- [Aula 1 e 2](https://github.com/GuillaumeFalourd/java-exercices/blob/main/BASICO/AULAS/aula-1-e-2.pdf)
-- [Aula 3](https://github.com/GuillaumeFalourd/java-exercices/blob/main/BASICO/AULAS/aula-3.pdf)
-- [Aula 4](https://github.com/GuillaumeFalourd/java-exercices/blob/main/BASICO/AULAS/aula-4.pdf)
-- [Java Básico](https://github.com/GuillaumeFalourd/java-exercices/blob/main/BASICO/AULAS/java-basico.pdf)
+- [Aula 1 e 2](https://github.com/GuillaumeFalourd/java-exercices/blob/main/0-BASICO/AULAS/aula-1-e-2.pdf)
+- [Aula 3](https://github.com/GuillaumeFalourd/java-exercices/blob/main/0-BASICO/AULAS/aula-3.pdf)
+- [Aula 4](https://github.com/GuillaumeFalourd/java-exercices/blob/main/0-BASICO/AULAS/aula-4.pdf)
+- [Java Básico](https://github.com/GuillaumeFalourd/java-exercices/blob/main/0-BASICO/AULAS/java-basico.pdf)


### PR DESCRIPTION
Corrigi os links quebrados no arquivo `README.md` dentro da pasta `BASICO`.

### Descrição
Os caminhos estavam desatualizados após mudanças nos nomes ou estrutura das pastas internas.  
Agora os links apontam corretamente para os arquivos PDF correspondentes.
